### PR TITLE
When CoMPAS call fails react as if not in CoMPAS.

### DIFF
--- a/src/compas-editors/CompasVersions.ts
+++ b/src/compas-editors/CompasVersions.ts
@@ -3,7 +3,7 @@ import {get, translate} from 'lit-translate';
 import {newLogEvent, newWizardEvent, Wizard} from "../foundation.js";
 
 import {CompasSclDataService, SDS_NAMESPACE} from "../compas-services/CompasSclDataService.js";
-import {createLogEvent, isNotFoundError, NOT_FOUND_ERROR} from "../compas-services/foundation.js";
+import {createLogEvent} from "../compas-services/foundation.js";
 import {getTypeFromDocName, updateDocumentInOpenSCD} from "../compas/foundation.js";
 import {getElementByName, getOpenScdElement, styles} from './foundation.js';
 import {addVersionToCompasWizard} from "../compas/CompasUploadVersion.js";
@@ -54,10 +54,8 @@ export default class CompasVersionsPlugin extends LitElement {
       .then(xmlResponse => {
         this.scls = Array.from(xmlResponse.querySelectorAll('Item') ?? []);
       })
-      .catch(reason => {
-        if (isNotFoundError(reason)) {
-          this.scls = [];
-        }
+      .catch(() => {
+        this.scls = [];
       });
   }
 

--- a/src/compas-services/foundation.ts
+++ b/src/compas-services/foundation.ts
@@ -69,10 +69,6 @@ export function handleError(error: Error): Promise<never> {
   return Promise.reject({type: SERVER_ERROR, message: error.message});
 }
 
-export function isNotFoundError(reason: any): boolean {
-  return (reason.type !== undefined && reason.type === NOT_FOUND_ERROR);
-}
-
 export function createLogEvent(reason: any): void {
   let message = reason.message;
   if (reason.status) {

--- a/src/compas/CompasExistsIn.ts
+++ b/src/compas/CompasExistsIn.ts
@@ -3,7 +3,6 @@ import {property} from "lit-element";
 import {LitElementConstructor, Mixin} from "../foundation.js";
 
 import {CompasSclDataService} from "../compas-services/CompasSclDataService.js";
-import {isNotFoundError, NOT_FOUND_ERROR} from "../compas-services/foundation.js";
 import {getTypeFromDocName} from "./foundation.js";
 
 export type CompasExistsInElement = Mixin<typeof CompasExistsIn>;
@@ -32,10 +31,8 @@ export function CompasExistsIn<TBase extends LitElementConstructor>(Base: TBase)
         const docType = getTypeFromDocName(this.docName);
         this.callService(docType, this.docId)
           .then(() => this.existInCompas = true)
-          .catch(reason => {
-            if (isNotFoundError(reason)) {
-              this.existInCompas = false;
-            }
+          .catch(() => {
+            this.existInCompas = false;
           });
       } else {
         this.existInCompas = false;

--- a/test/unit/compas-services/foundation.test.ts
+++ b/test/unit/compas-services/foundation.test.ts
@@ -1,10 +1,7 @@
 import {expect} from "@open-wc/testing";
 
 import {
-  isNotFoundError,
-  NOT_FOUND_ERROR,
   processErrorMessage,
-  SERVER_ERROR
 } from "../../../src/compas-services/foundation.js";
 
 const errorBody =
@@ -31,22 +28,6 @@ describe('compas-services-foundation', () => {
     const result = await processErrorMessage(response);
     expect(result).to.be.equal(expectedMessage);
 
-  })
-
-  it('when the error is caused by a status 404 then return true', () => {
-    const reason = {type: NOT_FOUND_ERROR};
-    const result = isNotFoundError(reason);
-    expect(result).to.be.true;
-  })
-  it('when the error is caused by other status then return false', () => {
-    const reason = {type: SERVER_ERROR};
-    const result = isNotFoundError(reason);
-    expect(result).to.be.false;
-  })
-  it('when no type of error found then return false', () => {
-    const reason = {};
-    const result = isNotFoundError(reason);
-    expect(result).to.be.false;
   })
 });
 


### PR DESCRIPTION
Function isNotFoundError no longer needed. 