### PR TITLE
Automatically Load NSDoc Files from SCL Validator Service

### DIFF
--- a/src/Logging.ts
+++ b/src/Logging.ts
@@ -245,8 +245,8 @@ export function Logging<TBase extends LitElementConstructor>(Base: TBase) {
 
       this.undo = this.undo.bind(this);
       this.redo = this.redo.bind(this);
-
       this.onLog = this.onLog.bind(this);
+
       this.addEventListener('log', this.onLog);
       this.addEventListener('issue', this.onIssue);
       this.addEventListener('open-doc', this.onLoadHistoryFromDoc);

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -63,13 +63,11 @@ export type LoadNsdocEvent = CustomEvent<LoadNsdocDetail>;
 export function newLoadNsdocEvent(
   nsdoc: string,
   filename: string,
-  eventInitDict?: CustomEventInit<Partial<LoadNsdocDetail>>
 ): LoadNsdocEvent {
   return new CustomEvent<LoadNsdocDetail>('load-nsdoc', {
     bubbles: true,
     composed: true,
-    ...eventInitDict,
-    detail: { nsdoc, filename, ...eventInitDict?.detail },
+    detail: { nsdoc, filename },
   });
 }
 

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -184,39 +184,6 @@ export function Setting<TBase extends LitElementConstructor>(Base: TBase) {
       if (changedProperties.has('settings')) use(this.settings.language);
     }
 
-    private renderFileSelect(): TemplateResult {
-      return html `
-        <input id="nsdoc-file" accept=".nsdoc" type="file" hidden required multiple
-          @change=${(evt: Event) => this.uploadNsdocFile(evt)}}>
-        <mwc-button label="${translate('settings.selectFileButton')}"
-                    id="selectFileButton"
-                    @click=${() => {
-                      const input = <HTMLInputElement | null>this.shadowRoot!.querySelector("#nsdoc-file");
-                      input?.click();
-                    }}>
-        </mwc-button>
-      `;
-    }
-
-    private async uploadNsdocFile(evt: Event): Promise<void> {
-      const files = Array.from(
-        (<HTMLInputElement | null>evt.target)?.files ?? []
-      );
-
-      if (files.length == 0) return;
-      for (const file of files) {
-        const text = await file.text();
-        document
-          .querySelector('open-scd')!
-          .dispatchEvent(
-            newLoadNsdocEvent(text, file.name)
-          );
-      }
-
-      this.nsdocFileUI.value = '';
-      this.requestUpdate();
-    }
-
     private async onLoadNsdoc(event: LoadNsdocEvent) {
       const nsdocElement = this.parseToXmlObject(event.detail.nsdoc).querySelector('NSDoc');
 
@@ -355,7 +322,6 @@ export function Setting<TBase extends LitElementConstructor>(Base: TBase) {
           <wizard-divider></wizard-divider>
           <section>
             <h3>${translate('settings.loadNsdTranslations')}</h3>
-            ${this.renderFileSelect()}
           </section>
           <mwc-list id="nsdocList">
             ${this.renderNsdocItem('IEC 61850-7-2')}

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -54,6 +54,25 @@ type NsdVersions = {
   'IEC 61850-8-1': NsdVersion;
 }
 
+/** Represents a document to be opened. */
+export interface LoadNsdocDetail {
+  nsdoc: string;
+  filename: string;
+}
+export type LoadNsdocEvent = CustomEvent<LoadNsdocDetail>;
+export function newLoadNsdocEvent(
+  nsdoc: string,
+  filename: string,
+  eventInitDict?: CustomEventInit<Partial<LoadNsdocDetail>>
+): LoadNsdocEvent {
+  return new CustomEvent<LoadNsdocDetail>('load-nsdoc', {
+    bubbles: true,
+    composed: true,
+    ...eventInitDict,
+    detail: { nsdoc, filename, ...eventInitDict?.detail },
+  });
+}
+
 /** Mixin that saves [[`Settings`]] to `localStorage`, reflecting them in the
  * `settings` property, setting them through `setSetting(setting, value)`. */
 export type SettingElement = Mixin<typeof Setting>;
@@ -168,7 +187,7 @@ export function Setting<TBase extends LitElementConstructor>(Base: TBase) {
     private renderFileSelect(): TemplateResult {
       return html `
         <input id="nsdoc-file" accept=".nsdoc" type="file" hidden required multiple
-          @change=${(evt: Event) => this.loadNsdocFile(evt)}}>
+          @change=${(evt: Event) => this.uploadNsdocFile(evt)}}>
         <mwc-button label="${translate('settings.selectFileButton')}"
                     id="selectFileButton"
                     @click=${() => {
@@ -179,50 +198,63 @@ export function Setting<TBase extends LitElementConstructor>(Base: TBase) {
       `;
     }
 
-    private async loadNsdocFile(evt: Event): Promise<void> {
-      const nsdVersions = await this.nsdVersions();
+    private async uploadNsdocFile(evt: Event): Promise<void> {
       const files = Array.from(
         (<HTMLInputElement | null>evt.target)?.files ?? []
       );
-      
-      if (files.length == 0) return;
-      files.forEach(async file => {
-        const text = await file.text();
-        const nsdocElement = this.parseToXmlObject(text).querySelector('NSDoc');
-        const id = nsdocElement?.getAttribute('id');
-        if (!id) {
-          document
-          .querySelector('open-scd')!
-          .dispatchEvent(
-              newLogEvent({ kind: 'error', title: get('settings.invalidFileNoIdFound') })
-            );
-          return;
-        }
-        const nsdVersion = nsdVersions[id as keyof NsdVersions];
-        const nsdocVersion = {
-          version: nsdocElement!.getAttribute('version') ?? '',
-          revision: nsdocElement!.getAttribute('revision') ?? '',
-          release: nsdocElement!.getAttribute('release') ?? ''
-        }
 
-        if (!this.isEqual(nsdVersion, nsdocVersion)) {
-          document
+      if (files.length == 0) return;
+      for (const file of files) {
+        const text = await file.text();
+        document
           .querySelector('open-scd')!
           .dispatchEvent(
-              newLogEvent({ kind: 'error', title: get('settings.invalidNsdocVersion', {
-                id: id,
-                nsdVersion: `${nsdVersion.version}${nsdVersion.revision}${nsdVersion.release}`,
-                nsdocVersion: `${nsdocVersion.version}${nsdocVersion.revision}${nsdocVersion.release}`
-              }) })
-            );
-          return;
-        }
-  
-        this.setSetting(id as keyof Settings, text);
-      })
+            newLoadNsdocEvent(text, file.name)
+          );
+      }
 
       this.nsdocFileUI.value = '';
       this.requestUpdate();
+    }
+
+    private async onLoadNsdoc(event: LoadNsdocEvent) {
+      const nsdocElement = this.parseToXmlObject(event.detail.nsdoc).querySelector('NSDoc');
+
+      const id = nsdocElement?.getAttribute('id');
+      if (!id) {
+        document
+          .querySelector('open-scd')!
+          .dispatchEvent(
+            newLogEvent({ kind: 'error', title: get('settings.invalidFileNoIdFound', {
+              filename: event.detail.filename
+            }) })
+          );
+        return;
+      }
+
+      const nsdVersions = await this.nsdVersions();
+      const nsdVersion = nsdVersions[id as keyof NsdVersions];
+      const nsdocVersion = {
+        version: nsdocElement!.getAttribute('version') ?? '',
+        revision: nsdocElement!.getAttribute('revision') ?? '',
+        release: nsdocElement!.getAttribute('release') ?? ''
+      }
+
+      if (!this.isEqual(nsdVersion, nsdocVersion)) {
+        document
+          .querySelector('open-scd')!
+          .dispatchEvent(
+            newLogEvent({ kind: 'error', title: get('settings.invalidNsdocVersion', {
+                id: id,
+                filename: event.detail.filename,
+                nsdVersion: `${nsdVersion.version}${nsdVersion.revision}${nsdVersion.release}`,
+                nsdocVersion: `${nsdocVersion.version}${nsdocVersion.revision}${nsdocVersion.release}`
+              }) })
+          );
+        return;
+      }
+
+      this.setSetting(id as keyof Settings, event.detail.nsdoc);
     }
 
     /**
@@ -245,7 +277,7 @@ export function Setting<TBase extends LitElementConstructor>(Base: TBase) {
       let nsdVersion: string | undefined | null;
       let nsdRevision: string | undefined | null;
       let nsdRelease: string | undefined | null;
-      
+
       if (nsdSetting) {
         const nsdoc = this.parseToXmlObject(nsdSetting)!.querySelector('NSDoc');
         nsdVersion = nsdoc?.getAttribute('version');
@@ -273,6 +305,8 @@ export function Setting<TBase extends LitElementConstructor>(Base: TBase) {
 
       registerTranslateConfig({ loader, empty: key => key });
       use(this.settings.language);
+
+      (<any>this).addEventListener('load-nsdoc', this.onLoadNsdoc);
     }
 
     render(): TemplateResult {

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -62,7 +62,7 @@ export interface LoadNsdocDetail {
 export type LoadNsdocEvent = CustomEvent<LoadNsdocDetail>;
 export function newLoadNsdocEvent(
   nsdoc: string,
-  filename: string,
+  filename: string
 ): LoadNsdocEvent {
   return new CustomEvent<LoadNsdocDetail>('load-nsdoc', {
     bubbles: true,

--- a/src/compas-services/CompasValidatorService.ts
+++ b/src/compas-services/CompasValidatorService.ts
@@ -10,8 +10,8 @@ export function CompasSclValidatorService() {
 
   return {
     validateSCL(type: string, doc: Document): Promise<Document> {
-      const saaUrl = getCompasSettings().sclValidatorServiceUrl + '/validate/v1/' + type;
-      return fetch(saaUrl, {
+      const svsUrl = getCompasSettings().sclValidatorServiceUrl + '/validate/v1/' + type;
+      return fetch(svsUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/xml'
@@ -21,6 +21,20 @@ export function CompasSclValidatorService() {
                  <svs:SclData><![CDATA[${new XMLSerializer().serializeToString(doc.documentElement)}]]></svs:SclData>
                </svs:SclValidateRequest>`
       }).catch(handleError)
+        .then(handleResponse)
+        .then(parseXml);
+    },
+
+    listNsdocFiles(): Promise<Document> {
+      const svsUrl = getCompasSettings().sclValidatorServiceUrl + '/nsdoc/v1';
+      return fetch(svsUrl).catch(handleError)
+        .then(handleResponse)
+        .then(parseXml);
+    },
+
+    getNsdocFile(id: string): Promise<Document> {
+      const svsUrl = getCompasSettings().sclValidatorServiceUrl + '/nsdoc/v1/' + id;
+      return fetch(svsUrl).catch(handleError)
         .then(handleResponse)
         .then(parseXml);
     },

--- a/src/compas-services/CompasValidatorService.ts
+++ b/src/compas-services/CompasValidatorService.ts
@@ -32,11 +32,10 @@ export function CompasSclValidatorService() {
         .then(parseXml);
     },
 
-    getNsdocFile(id: string): Promise<Document> {
+    getNsdocFile(id: string): Promise<string> {
       const svsUrl = getCompasSettings().sclValidatorServiceUrl + '/nsdoc/v1/' + id;
       return fetch(svsUrl).catch(handleError)
-        .then(handleResponse)
-        .then(parseXml);
+        .then(handleResponse);
     },
   }
 }

--- a/src/compas/CompasNsdoc.ts
+++ b/src/compas/CompasNsdoc.ts
@@ -1,10 +1,42 @@
+import {newLoadNsdocEvent} from "../Setting.js";
+import {dispatchEventOnOpenScd} from "./foundation.js";
+
 import {createLogEvent} from "../compas-services/foundation.js";
 import {CompasSclValidatorService} from "../compas-services/CompasValidatorService.js";
 
-function processNsdocFile(id: string, nsdocId: string, checksum: string) {
-  console.info(`Found NSDoc File '${nsdocId}' with ID '${id}'.`);
+/**
+ * Load a single entry. Use the nsdocId to look in the Local Storage, if already loaded,
+ * and if the checksum is the same.
+ * If one of them isn't the case use the ID to retrieve the content of the NSDoc File and
+ * fire the #newLoadNsdocEvent to add the content to the Local Storage.
+ *
+ * @param id       - A unique id use to retrieve the content of NSDoc File from the SCL Validator Service.
+ * @param nsdocId  - The NSDoc ID to be used in the Local Storage.
+ * @param filename - The name of the file, just for logging.
+ * @param checksum - The checksum of the NSDoc File in the SCL Validator Service.
+ */
+async function processNsdocFile(id: string, nsdocId: string, filename: string, checksum: string): Promise<void> {
+  const checksumKey = nsdocId + '.checksum';
+  const checksumStored = localStorage.getItem(checksumKey);
+  if (localStorage.getItem(nsdocId) === null || checksumStored === null || checksumStored !== checksum) {
+    console.info(`Loading NSDoc File '${nsdocId}' with ID '${id}'.`);
+    await CompasSclValidatorService().getNsdocFile(id)
+      .then(nsdocContent => {
+        dispatchEventOnOpenScd(newLoadNsdocEvent(nsdocContent, filename));
+        localStorage.setItem(checksumKey, checksum);
+      })
+      .catch(reason => {
+        createLogEvent(reason);
+      });
+  } else {
+    console.debug(`Loading NSDoc File '${nsdocId}' skipped, already loaded.`);
+  }
 }
 
+/**
+ * Call backend to get the list of available NSDoc Files on the SCL Validator Service.
+ * Load each item found using the function #processNsdocFile.
+ */
 export async function loadNsdocFiles(): Promise<void> {
   await CompasSclValidatorService().listNsdocFiles()
     .then(response => {
@@ -12,8 +44,9 @@ export async function loadNsdocFiles(): Promise<void> {
         .forEach(element => {
           const id = element.querySelector('Id')!.textContent ?? '';
           const nsdocId = element.querySelector('NsdocId')!.textContent ?? '';
+          const filename = element.querySelector('Filename')!.textContent ?? '';
           const checksum = element.querySelector('Checksum')!.textContent ?? '';
-          processNsdocFile(id, nsdocId, checksum);
+          processNsdocFile(id, nsdocId, filename, checksum);
         });
     })
     .catch(reason => {

--- a/src/compas/CompasNsdoc.ts
+++ b/src/compas/CompasNsdoc.ts
@@ -1,0 +1,22 @@
+import {createLogEvent} from "../compas-services/foundation.js";
+import {CompasSclValidatorService} from "../compas-services/CompasValidatorService.js";
+
+function processNsdocFile(id: string, nsdocId: string, checksum: string) {
+  console.info(`Found NSDoc File '${nsdocId}' with ID '${id}'.`);
+}
+
+export async function loadNsdocFiles(): Promise<void> {
+  await CompasSclValidatorService().listNsdocFiles()
+    .then(response => {
+      Array.from(response.querySelectorAll("NsdocFile") ?? [])
+        .forEach(element => {
+          const id = element.querySelector('Id')!.textContent ?? '';
+          const nsdocId = element.querySelector('NsdocId')!.textContent ?? '';
+          const checksum = element.querySelector('Checksum')!.textContent ?? '';
+          processNsdocFile(id, nsdocId, checksum);
+        });
+    })
+    .catch(reason => {
+      createLogEvent(reason);
+    });
+}

--- a/src/menu/CompasSettings.ts
+++ b/src/menu/CompasSettings.ts
@@ -5,6 +5,7 @@ import {newWizardEvent, Wizard, WizardInput} from '../foundation.js';
 
 import {CompasSettingsElement} from "../compas/CompasSettings.js";
 import {retrieveUserInfo} from "../compas/CompasSession.js";
+import {loadNsdocFiles} from "../compas/CompasNsdoc.js";
 
 import "../compas/CompasSettings.js";
 
@@ -42,4 +43,6 @@ export function compasSettingWizard(): Wizard {
 
 // When the plugin is loaded we will also start retrieving the User Information and prepare the Timeout Panels.
 retrieveUserInfo();
+// And we will start loading the Nsdoc Files from the Compas Backend Service.
+loadNsdocFiles();
 

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -70,10 +70,9 @@ export const de: Translations = {
     showieds: 'Zeige IEDs im Substation-Editor',
     selectFileButton: 'Datei auswählen',
     loadNsdTranslations: 'NSDoc-Dateien hochladen',
-    invalidFileNoIdFound:
-      "Ungültiges NSDoc; kein 'id'-Attribut in der Datei gefunden",
+    invalidFileNoIdFound: "Ungültiges NSDoc ({{ filename }}); kein 'id'-Attribut in der Datei gefunden",
     invalidNsdocVersion:
-      'Die Version {{ id }} NSD ({{ nsdVersion }}) passt nicht zu der geladenen NSDoc ({{ nsdocVersion }})',
+      'Die Version {{ id }} NSD ({{ nsdVersion }}) passt nicht zu der geladenen NSDoc ({{ filename }}, {{ nsdocVersion }})',
   },
   menu: {
     new: 'Neues projekt',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -67,10 +67,10 @@ export const en = {
     mode: 'Pro mode',
     showieds: 'Show IEDs in substation editor',
     selectFileButton: 'Select file',
-    loadNsdTranslations: 'Uploading NSDoc files',
-    invalidFileNoIdFound: "Invalid NSDoc; no 'id' attribute found in file",
+    loadNsdTranslations: 'Uploaded NSDoc files',
+    invalidFileNoIdFound: "Invalid NSDoc ({{ filename }}); no 'id' attribute found in file",
     invalidNsdocVersion:
-      'The version of {{ id }} NSD ({{ nsdVersion }}) does not correlate with the version of the corresponding NSDoc ({{ nsdocVersion }})',
+      'The version of {{ id }} NSD ({{ nsdVersion }}) does not correlate with the version of the corresponding NSDoc ({{ filename }}, {{ nsdocVersion }})',
   },
   menu: {
     new: 'New project',

--- a/test/integration/Setting.test.ts
+++ b/test/integration/Setting.test.ts
@@ -1,0 +1,85 @@
+import { html, fixture, expect } from '@open-wc/testing';
+
+import '../../src/open-scd.js';
+
+import { OpenSCD } from '../../src/open-scd.js';
+import { newLoadNsdocEvent } from "../../src/Setting.js";
+import { cleanLocalStorageForNsdocFiles } from "../unit/foundation/nsdoc.test.js";
+
+describe('Setting', () => {
+  let element: OpenSCD;
+
+  beforeEach(async () => {
+    cleanLocalStorageForNsdocFiles();
+
+    element = await fixture(html`
+      <open-scd></open-scd>
+
+      <link href="public/google/fonts/roboto-v27.css" rel="stylesheet" />
+      <link href="public/google/fonts/roboto-mono-v13.css" rel="stylesheet" />
+      <link href="public/google/icons/material-icons-outlined.css" rel="stylesheet" />
+    `);
+  });
+
+  it('opens the log on log menu entry click', async () => {
+    await (<HTMLElement>(
+      element.shadowRoot!.querySelector('mwc-list-item[iconid="history"]')!
+    )).click();
+    expect(element.logUI).to.have.property('open', true);
+  });
+
+  it('upload .nsdoc file using event and looks like latest snapshot', async () => {
+    element.settingsUI.show();
+    await element.settingsUI.updateComplete;
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc')
+      .then(response => response.text())
+
+    element.dispatchEvent(
+      newLoadNsdocEvent(nsdocFile, 'IEC_61850-7-2.nsdoc')
+    );
+
+    await element.requestUpdate();
+    await element.updateComplete;
+
+    expect(localStorage.getItem('IEC 61850-7-2')).to.eql(nsdocFile);
+    expect(element).shadowDom.to.equalSnapshot();
+  });
+
+  it('upload invalid .nsdoc file using event and log event fired', async () => {
+    element.settingsUI.show();
+    await element.settingsUI.updateComplete;
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/invalid.nsdoc')
+      .then(response => response.text())
+
+    element.dispatchEvent(
+      newLoadNsdocEvent(nsdocFile, 'invalid.nsdoc')
+    );
+
+    await element.requestUpdate();
+    await element.updateComplete;
+
+    expect(element.history.length).to.be.equal(1);
+    expect(element.history[0].title).to.be.equal('Invalid NSDoc (invalid.nsdoc); no \'id\' attribute found in file');
+  });
+
+  it('upload .nsdoc file with wrong version using event and log event fired', async () => {
+    element.settingsUI.show();
+    await element.settingsUI.updateComplete;
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/wrong-version.nsdoc')
+      .then(response => response.text())
+
+    element.dispatchEvent(
+      newLoadNsdocEvent(nsdocFile, 'wrong-version.nsdoc')
+    );
+
+    await element.requestUpdate();
+    await element.updateComplete;
+
+    expect(element.history.length).to.be.equal(1);
+    expect(element.history[0].title).to.be.equal('The version of IEC 61850-7-3 NSD (2007B3) does not correlate ' +
+      'with the version of the corresponding NSDoc (wrong-version.nsdoc, 2007B4)');
+  });
+}).timeout(4000);

--- a/test/integration/Setting.test.ts
+++ b/test/integration/Setting.test.ts
@@ -4,7 +4,7 @@ import '../../src/open-scd.js';
 
 import { OpenSCD } from '../../src/open-scd.js';
 import { newLoadNsdocEvent } from "../../src/Setting.js";
-import { cleanLocalStorageForNsdocFiles } from "../unit/foundation/nsdoc.test.js";
+import { cleanLocalStorageForNsdocFiles } from "./foundation.js";
 
 describe('Setting', () => {
   let element: OpenSCD;

--- a/test/integration/Setting.test.ts
+++ b/test/integration/Setting.test.ts
@@ -4,13 +4,12 @@ import '../../src/open-scd.js';
 
 import { OpenSCD } from '../../src/open-scd.js';
 import { newLoadNsdocEvent } from "../../src/Setting.js";
-import { cleanLocalStorageForNsdocFiles } from "./foundation.js";
 
 describe('Setting', () => {
   let element: OpenSCD;
 
   beforeEach(async () => {
-    cleanLocalStorageForNsdocFiles();
+    localStorage.clear();
 
     element = await fixture(html`
       <open-scd></open-scd>

--- a/test/integration/__snapshots__/Setting.test.snap.js
+++ b/test/integration/__snapshots__/Setting.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Setting upload .nsdoc file using event and looks like latest snapshot"] = 
+snapshots["Setting upload .nsdoc file using event and looks like latest snapshot"] =
 `<mwc-drawer
   class="mdc-theme--surface"
   hasheader=""
@@ -1138,19 +1138,6 @@ snapshots["Setting upload .nsdoc file using event and looks like latest snapshot
     <h3>
       Uploaded NSDoc files
     </h3>
-    <input
-      accept=".nsdoc"
-      hidden=""
-      id="nsdoc-file"
-      multiple=""
-      required=""
-      type="file"
-    >
-    <mwc-button
-      id="selectFileButton"
-      label="Select file"
-    >
-    </mwc-button>
   </section>
   <mwc-list id="nsdocList">
     <mwc-list-item

--- a/test/integration/__snapshots__/Setting.test.snap.js
+++ b/test/integration/__snapshots__/Setting.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["open-scd looks like its snapshot"] = 
+snapshots["Setting upload .nsdoc file using event and looks like latest snapshot"] = 
 `<mwc-drawer
   class="mdc-theme--surface"
   hasheader=""
@@ -48,23 +48,6 @@ snapshots["open-scd looks like its snapshot"] =
       </mwc-icon>
       <span>
         New project
-      </span>
-      <mwc-linear-progress indeterminate="">
-      </mwc-linear-progress>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      class="top"
-      graphic="icon"
-      iconid="input"
-      mwc-list-item=""
-      tabindex="-1"
-    >
-      <mwc-icon slot="graphic">
-        input
-      </mwc-icon>
-      <span>
-        Project from CIM
       </span>
       <mwc-linear-progress indeterminate="">
       </mwc-linear-progress>
@@ -124,24 +107,6 @@ snapshots["open-scd looks like its snapshot"] =
       <span>
         Redo
       </span>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="true"
-      class="validator"
-      disabled=""
-      graphic="icon"
-      iconid="rule_folder"
-      mwc-list-item=""
-      tabindex="-1"
-    >
-      <mwc-icon slot="graphic">
-        rule_folder
-      </mwc-icon>
-      <span>
-        Validate using OCL
-      </span>
-      <mwc-linear-progress indeterminate="">
-      </mwc-linear-progress>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="true"
@@ -287,24 +252,6 @@ snapshots["open-scd looks like its snapshot"] =
       <mwc-linear-progress indeterminate="">
       </mwc-linear-progress>
     </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="true"
-      class="middle"
-      disabled=""
-      graphic="icon"
-      iconid="dashboard"
-      mwc-list-item=""
-      tabindex="-1"
-    >
-      <mwc-icon slot="graphic">
-        dashboard
-      </mwc-icon>
-      <span>
-        Auto Align SLD
-      </span>
-      <mwc-linear-progress indeterminate="">
-      </mwc-linear-progress>
-    </mwc-list-item>
     <li
       divider=""
       padded=""
@@ -325,23 +272,6 @@ snapshots["open-scd looks like its snapshot"] =
       <span>
         Settings
       </span>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      class="middle"
-      graphic="icon"
-      iconid="settings"
-      mwc-list-item=""
-      tabindex="-1"
-    >
-      <mwc-icon slot="graphic">
-        settings
-      </mwc-icon>
-      <span>
-        CoMPAS Settings
-      </span>
-      <mwc-linear-progress indeterminate="">
-      </mwc-linear-progress>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -437,14 +367,6 @@ snapshots["open-scd looks like its snapshot"] =
   >
     <div class="landing_label">
       New project
-    </div>
-  </mwc-icon-button>
-  <mwc-icon-button
-    class="landing_icon"
-    icon="input"
-  >
-    <div class="landing_label">
-      Project from CIM
     </div>
   </mwc-icon-button>
 </div>
@@ -659,7 +581,6 @@ snapshots["open-scd looks like its snapshot"] =
       hasmeta=""
       left=""
       mwc-list-item=""
-      selected=""
       tabindex="-1"
       value="/src/editors/IED.js"
     >
@@ -675,7 +596,6 @@ snapshots["open-scd looks like its snapshot"] =
       hasmeta=""
       left=""
       mwc-list-item=""
-      selected=""
       tabindex="-1"
       value="/src/editors/SingleLineDiagram.js"
     >
@@ -755,22 +675,6 @@ snapshots["open-scd looks like its snapshot"] =
       hasmeta=""
       left=""
       mwc-list-item=""
-      selected=""
-      tabindex="-1"
-      value="/src/compas-editors/CompasVersions.js"
-    >
-      <mwc-icon slot="meta">
-        copy_all
-      </mwc-icon>
-      CoMPAS Versions
-    </mwc-check-list-item>
-    <mwc-check-list-item
-      aria-disabled="false"
-      class="official"
-      graphic="control"
-      hasmeta=""
-      left=""
-      mwc-list-item=""
       tabindex="-1"
       value="/src/editors/Cleanup.js"
     >
@@ -811,7 +715,7 @@ snapshots["open-scd looks like its snapshot"] =
       mwc-list-item=""
       selected=""
       tabindex="-1"
-      value="/src/menu/CompasOpen.js"
+      value="/src/menu/OpenProject.js"
     >
       <mwc-icon slot="meta">
         folder_open
@@ -843,23 +747,7 @@ snapshots["open-scd looks like its snapshot"] =
       mwc-list-item=""
       selected=""
       tabindex="-1"
-      value="/src/menu/CompasCimMapping.js"
-    >
-      <mwc-icon slot="meta">
-        input
-      </mwc-icon>
-      Project from CIM
-    </mwc-check-list-item>
-    <mwc-check-list-item
-      aria-disabled="false"
-      class="official"
-      graphic="control"
-      hasmeta=""
-      left=""
-      mwc-list-item=""
-      selected=""
-      tabindex="-1"
-      value="/src/menu/CompasSave.js"
+      value="/src/menu/SaveProject.js"
     >
       <mwc-icon slot="meta">
         save
@@ -872,22 +760,6 @@ snapshots["open-scd looks like its snapshot"] =
       role="separator"
     >
     </li>
-    <mwc-check-list-item
-      aria-disabled="false"
-      class="official"
-      graphic="control"
-      hasmeta=""
-      left=""
-      mwc-list-item=""
-      selected=""
-      tabindex="-1"
-      value="/src/validators/ValidateSchemaWithCompas.js"
-    >
-      <mwc-icon slot="meta">
-        rule_folder
-      </mwc-icon>
-      Validate using OCL
-    </mwc-check-list-item>
     <mwc-check-list-item
       aria-disabled="false"
       class="official"
@@ -935,7 +807,7 @@ snapshots["open-scd looks like its snapshot"] =
       mwc-list-item=""
       selected=""
       tabindex="-1"
-      value="/src/menu/CompasImportIEDs.js"
+      value="/src/menu/ImportIEDs.js"
     >
       <mwc-icon slot="meta">
         snippet_folder
@@ -997,7 +869,7 @@ snapshots["open-scd looks like its snapshot"] =
       mwc-list-item=""
       selected=""
       tabindex="-1"
-      value="/src/menu/CompasMerge.js"
+      value="/src/menu/Merge.js"
     >
       <mwc-icon slot="meta">
         merge_type
@@ -1013,43 +885,12 @@ snapshots["open-scd looks like its snapshot"] =
       mwc-list-item=""
       selected=""
       tabindex="-1"
-      value="/src/menu/CompasUpdateSubstation.js"
+      value="/src/menu/UpdateSubstation.js"
     >
       <mwc-icon slot="meta">
         merge_type
       </mwc-icon>
       Update Substation
-    </mwc-check-list-item>
-    <mwc-check-list-item
-      aria-disabled="false"
-      class="official"
-      graphic="control"
-      hasmeta=""
-      left=""
-      mwc-list-item=""
-      selected=""
-      tabindex="-1"
-      value="/src/menu/CompasAutoAlignment.js"
-    >
-      <mwc-icon slot="meta">
-        dashboard
-      </mwc-icon>
-      Auto Align SLD
-    </mwc-check-list-item>
-    <mwc-check-list-item
-      aria-disabled="false"
-      class="official"
-      graphic="control"
-      hasmeta=""
-      left=""
-      mwc-list-item=""
-      tabindex="-1"
-      value="/src/menu/LocamationVMU.js"
-    >
-      <mwc-icon slot="meta">
-        edit_note
-      </mwc-icon>
-      Locamation VMU
     </mwc-check-list-item>
     <li
       divider=""
@@ -1057,22 +898,6 @@ snapshots["open-scd looks like its snapshot"] =
       role="separator"
     >
     </li>
-    <mwc-check-list-item
-      aria-disabled="false"
-      class="official"
-      graphic="control"
-      hasmeta=""
-      left=""
-      mwc-list-item=""
-      selected=""
-      tabindex="-1"
-      value="/src/menu/CompasSettings.js"
-    >
-      <mwc-icon slot="meta">
-        settings
-      </mwc-icon>
-      CoMPAS Settings
-    </mwc-check-list-item>
     <mwc-check-list-item
       aria-disabled="false"
       class="official"
@@ -1262,6 +1087,7 @@ snapshots["open-scd looks like its snapshot"] =
 <mwc-dialog
   heading="Settings"
   id="settings"
+  open=""
 >
   <form>
     <mwc-select
@@ -1328,8 +1154,7 @@ snapshots["open-scd looks like its snapshot"] =
   </section>
   <mwc-list id="nsdocList">
     <mwc-list-item
-      aria-disabled="true"
-      disabled=""
+      aria-disabled="false"
       graphic="avatar"
       hasmeta=""
       id="IEC 61850-7-2"
@@ -1340,11 +1165,20 @@ snapshots["open-scd looks like its snapshot"] =
       <span>
         IEC 61850-7-2
       </span>
+      <span slot="secondary">
+        2007B3
+      </span>
       <mwc-icon
         slot="graphic"
-        style="color:red;"
+        style="color:green;"
       >
-        close
+        done
+      </mwc-icon>
+      <mwc-icon
+        id="deleteNsdocItem"
+        slot="meta"
+      >
+        delete
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
@@ -1430,10 +1264,6 @@ snapshots["open-scd looks like its snapshot"] =
     Save
   </mwc-button>
 </mwc-dialog>
-<compas-session-expiring-dialog>
-</compas-session-expiring-dialog>
-<compas-session-expired-dialog>
-</compas-session-expired-dialog>
 `;
-/* end snapshot open-scd looks like its snapshot */
+/* end snapshot Setting upload .nsdoc file using event and looks like latest snapshot */
 

--- a/test/integration/__snapshots__/open-scd.test.snap.js
+++ b/test/integration/__snapshots__/open-scd.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["open-scd looks like its snapshot"] = 
+snapshots["open-scd looks like its snapshot"] =
 `<mwc-drawer
   class="mdc-theme--surface"
   hasheader=""
@@ -1312,19 +1312,6 @@ snapshots["open-scd looks like its snapshot"] =
     <h3>
       Uploaded NSDoc files
     </h3>
-    <input
-      accept=".nsdoc"
-      hidden=""
-      id="nsdoc-file"
-      multiple=""
-      required=""
-      type="file"
-    >
-    <mwc-button
-      id="selectFileButton"
-      label="Select file"
-    >
-    </mwc-button>
   </section>
   <mwc-list id="nsdocList">
     <mwc-list-item

--- a/test/integration/foundation.ts
+++ b/test/integration/foundation.ts
@@ -1,7 +1,0 @@
-export function cleanLocalStorageForNsdocFiles(): void {
-  // Cleanup NSDoc Files from LocalStorage
-  localStorage.removeItem('IEC 61850-7-2');
-  localStorage.removeItem('IEC 61850-7-3');
-  localStorage.removeItem('IEC 61850-7-4');
-  localStorage.removeItem('IEC 61850-8-1');
-}

--- a/test/integration/foundation.ts
+++ b/test/integration/foundation.ts
@@ -1,0 +1,7 @@
+export function cleanLocalStorageForNsdocFiles(): void {
+  // Cleanup NSDoc Files from LocalStorage
+  localStorage.removeItem('IEC 61850-7-2');
+  localStorage.removeItem('IEC 61850-7-3');
+  localStorage.removeItem('IEC 61850-7-4');
+  localStorage.removeItem('IEC 61850-8-1');
+}

--- a/test/integration/open-scd.test.ts
+++ b/test/integration/open-scd.test.ts
@@ -3,7 +3,7 @@ import { html, fixture, expect } from '@open-wc/testing';
 import '../../src/open-scd.js';
 import { newEmptySCD } from '../../src/schemas.js';
 import { OpenSCD } from '../../src/open-scd.js';
-import { cleanLocalStorageForNsdocFiles } from "../unit/foundation/nsdoc.test.js";
+import { cleanLocalStorageForNsdocFiles } from "./foundation.js";
 
 describe('open-scd', () => {
   let element: OpenSCD;

--- a/test/integration/open-scd.test.ts
+++ b/test/integration/open-scd.test.ts
@@ -3,7 +3,6 @@ import { html, fixture, expect } from '@open-wc/testing';
 import '../../src/open-scd.js';
 import { newEmptySCD } from '../../src/schemas.js';
 import { OpenSCD } from '../../src/open-scd.js';
-import { cleanLocalStorageForNsdocFiles } from "./foundation.js";
 
 describe('open-scd', () => {
   let element: OpenSCD;
@@ -11,7 +10,7 @@ describe('open-scd', () => {
   let validSCL: string;
 
   beforeEach(async () => {
-    cleanLocalStorageForNsdocFiles();
+    localStorage.clear();
 
     invalidSCL = await fetch('/test/testfiles/invalid2007B.scd').then(
       response => response.text()

--- a/test/integration/open-scd.test.ts
+++ b/test/integration/open-scd.test.ts
@@ -3,6 +3,7 @@ import { html, fixture, expect } from '@open-wc/testing';
 import '../../src/open-scd.js';
 import { newEmptySCD } from '../../src/schemas.js';
 import { OpenSCD } from '../../src/open-scd.js';
+import { cleanLocalStorageForNsdocFiles } from "../unit/foundation/nsdoc.test.js";
 
 describe('open-scd', () => {
   let element: OpenSCD;
@@ -10,6 +11,8 @@ describe('open-scd', () => {
   let validSCL: string;
 
   beforeEach(async () => {
+    cleanLocalStorageForNsdocFiles();
+
     invalidSCL = await fetch('/test/testfiles/invalid2007B.scd').then(
       response => response.text()
     );
@@ -21,10 +24,7 @@ describe('open-scd', () => {
 
       <link href="public/google/fonts/roboto-v27.css" rel="stylesheet" />
       <link href="public/google/fonts/roboto-mono-v13.css" rel="stylesheet" />
-      <link
-        href="public/google/icons/material-icons-outlined.css"
-        rel="stylesheet"
-      />
+      <link href="public/google/icons/material-icons-outlined.css" rel="stylesheet" />
     `);
   });
 

--- a/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc
+++ b/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NSDoc id="IEC 61850-7-2"
+       version="2007"
+       revision="B"
+       release="3"
+       lang="en">
+</NSDoc>

--- a/test/testfiles/nsdoc/invalid.nsdoc
+++ b/test/testfiles/nsdoc/invalid.nsdoc
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: 2022 Alliander -->
+<!-- -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<NSDoc>
+</NSDoc>

--- a/test/testfiles/nsdoc/wrong-version.nsdoc
+++ b/test/testfiles/nsdoc/wrong-version.nsdoc
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NSDoc id="IEC 61850-7-3"
+       version="2007"
+       revision="B"
+       release="4"
+       lang="en">
+</NSDoc>

--- a/test/testfiles/settingTest.nsdoc
+++ b/test/testfiles/settingTest.nsdoc
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<NSDoc id="IEC 61850-7-2" lang="en">
-</NSDoc>

--- a/test/unit/Setting.test.ts
+++ b/test/unit/Setting.test.ts
@@ -52,12 +52,12 @@ describe('SettingElement', () => {
   it('saves chosen .nsdoc file and looks like latest snapshot', async () => {
     element.settingsUI.show();
     await element.settingsUI.updateComplete;
-  
-    const nsdocFile = await fetch('/test/testfiles/settingTest.nsdoc')
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc')
       .then(response => response.text())
 
     element.setSetting('IEC 61850-7-2', nsdocFile);
-    
+
     await element.requestUpdate();
     await element.updateComplete;
 
@@ -68,19 +68,19 @@ describe('SettingElement', () => {
   it('deletes a chosen .nsdoc file and looks like latest snapshot', async () => {
     element.settingsUI.show();
     await element.settingsUI.updateComplete;
-  
-    const nsdocFile = await fetch('/test/testfiles/settingTest.nsdoc')
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc')
       .then(response => response.text())
 
     element.setSetting('IEC 61850-7-2', nsdocFile);
-    
+
     await element.requestUpdate();
     await element.updateComplete;
 
     (<Button>(
       element.settingsUI.querySelector('mwc-icon[id="deleteNsdocItem"]')
     )).click();
-    
+
     await element.requestUpdate();
     await element.updateComplete;
 

--- a/test/unit/foundation/nsdoc.test.ts
+++ b/test/unit/foundation/nsdoc.test.ts
@@ -146,11 +146,3 @@ describe('nsdoc', () => {
     });
   });
 });
-
-export function cleanLocalStorageForNsdocFiles() {
-  // Cleanup NSDoc Files from LocalStorage
-  localStorage.removeItem('IEC 61850-7-2');
-  localStorage.removeItem('IEC 61850-7-3');
-  localStorage.removeItem('IEC 61850-7-4');
-  localStorage.removeItem('IEC 61850-8-1');
-}

--- a/test/unit/foundation/nsdoc.test.ts
+++ b/test/unit/foundation/nsdoc.test.ts
@@ -63,7 +63,7 @@ describe('nsdoc', () => {
         it('returns the lnClass in case no title can be found', async function () {
           const ln = validSCL.querySelector(
             'IED[name="IED1"] > AccessPoint[name="P1"] > Server > LDevice[inst="CircuitBreaker_CB1"] > LN[lnClass="XCBR"]');
-      
+
             expect(nsdocsObject.getDataDescription(ln!).label).to.eql('XCBR');
         });
       });
@@ -71,19 +71,19 @@ describe('nsdoc', () => {
       describe('which for DO elements', () => {
         it('returns the description', async function () {
           const dataObject = validSCL.querySelector('LNodeType[id="Dummy.LLN0"] > DO[name="Beh"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Some DO description');
         });
-  
+
         it('returns the description where the DO is part of a parent class', async function () {
           const dataObject = validSCL.querySelector('LNodeType[id="Dummy.XCBR1"] > DO[name="Beh"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Some DomainLN Description');
         });
-  
+
         it('returns the name in case no description can be found', async function () {
           const dataObject = validSCL.querySelector('LNodeType[id="Dummy.LLN0"] > DO[name="Health"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Health');
         });
       });
@@ -91,25 +91,25 @@ describe('nsdoc', () => {
       describe('which for DA elements', () => {
         it('returns the description defined in IEC 61850-7-3', async function () {
           const dataObject = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="q"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Some DA description');
         });
-  
+
         it('returns the name in case no description can be found in IEC 61850-7-3', async function () {
           const dataObject = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="t"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('t');
         });
-  
+
         it('returns the description defined in IEC 61850-8-1', async function () {
           const dataObject = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="SBOw"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Some SBOw title');
         });
-  
+
         it('which returns the name in case no description can be found in IEC 61850-8-1', async function () {
           const dataObject = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="SBO"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('SBO');
         });
       });
@@ -118,31 +118,39 @@ describe('nsdoc', () => {
         it('returns the description defined in IEC 61850-7-3', async function () {
           const bdaElement = validSCL.querySelector('DAType[id="AnalogueValue_i"] > BDA[name="i"]');
           const bdaElementParent = validSCL.querySelector('DOType[id="DummySAV"] > DA[name="instMag"]');
-  
+
           expect(nsdocsObject.getDataDescription(bdaElement!, [bdaElementParent!]).label).to.eql('Some i description');
         });
-  
+
         it('returns the name in case no description can be found in IEC 61850-7-3', async function () {
           const bdaElement = validSCL.querySelector('DAType[id="AnalogueValue_i"] > BDA[name="x"]');
           const bdaElementParent = validSCL.querySelector('DOType[id="DummySAV"] > DA[name="instMag"]');
-  
+
           expect(nsdocsObject.getDataDescription(bdaElement!, [bdaElementParent!]).label).to.eql('x');
         });
-  
+
         it('returns the description defined in IEC 61850-8-1', async function () {
           const bdaElement = validSCL.querySelector('DAType[id="Dummy.LLN0.Mod.SBOw"] > BDA[name="ctlNum"]');
           const bdaElementParent = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="SBOw"]');
-  
+
           expect(nsdocsObject.getDataDescription(bdaElement!, [bdaElementParent!]).label).to.eql('Some ctlNum description');
         });
-  
+
         it('returns the name in case no description can be found in IEC 61850-8-1', async function () {
           const bdaElement = validSCL.querySelector('DAType[id="Dummy.LLN0.Mod.SBOw"] > BDA[name="T"]');
           const bdaElementParent = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="SBOw"]');
-  
+
           expect(nsdocsObject.getDataDescription(bdaElement!, [bdaElementParent!]).label).to.eql('T');
         });
       });
     });
   });
 });
+
+export function cleanLocalStorageForNsdocFiles() {
+  // Cleanup NSDoc Files from LocalStorage
+  localStorage.removeItem('IEC 61850-7-2');
+  localStorage.removeItem('IEC 61850-7-3');
+  localStorage.removeItem('IEC 61850-7-4');
+  localStorage.removeItem('IEC 61850-8-1');
+}


### PR DESCRIPTION
When CoMPAS OpenSCD is loaded, just like retrieving the User Info, the NSDoc Info will be retrieve to determine if any NSDoc Files need to be loaded automatically.

closes #120 