### PR TITLE
Make it possible to replace NGiNX configuration through volume.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM nginx:latest
 COPY build/. /usr/share/nginx/html/
 
+VOLUME /etc/nginx/conf.d
 VOLUME /usr/share/nginx/html/public/cim


### PR DESCRIPTION
There is now a volume /etc/nginx/conf.d to make it possible to use your own NGiNX configuration if needed.
When using this volume some replacement of the default.conf needs to be there to configure a server on port 80.
If the volume isn't mapped there is the default.conf from NGiNX running on port 80 serving the directory /usr/share/nginx/html.