### PR TITLE
Refactor of Websocket wrapper to use promise.

### DIFF
--- a/src/compas-services/CompasSclDataService.ts
+++ b/src/compas-services/CompasSclDataService.ts
@@ -8,7 +8,7 @@ import {
   handleResponse,
   parseXml,
 } from './foundation.js';
-import { websockets } from './Websockets.js';
+import { websocket } from './Websocket.js';
 
 export const SDS_NAMESPACE =
   'https://www.lfenergy.org/compas/SclDataService/v1';
@@ -93,7 +93,7 @@ export function CompasSclDataService() {
          </sds:GetWsRequest>`;
 
         const sclUrl = getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/get';
-        return websockets(
+        return websocket(
           element,
           'CompasSclDataService',
           getWebsocketUri(sclUrl),
@@ -124,7 +124,7 @@ export function CompasSclDataService() {
 
         const sclUrl =
           getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/get-version';
-        return websockets(
+        return websocket(
           element,
           'CompasSclDataService',
           getWebsocketUri(sclUrl),
@@ -177,7 +177,7 @@ export function CompasSclDataService() {
 
         const sclUrl =
           getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/create';
-        return websockets(
+        return websocket(
           element,
           'CompasSclDataService',
           getWebsocketUri(sclUrl),
@@ -227,7 +227,7 @@ export function CompasSclDataService() {
 
         const sclUrl =
           getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/update';
-        return websockets(
+        return websocket(
           element,
           'CompasSclDataService',
           getWebsocketUri(sclUrl),

--- a/src/compas-services/CompasSclDataService.ts
+++ b/src/compas-services/CompasSclDataService.ts
@@ -2,12 +2,13 @@ import { formatXml } from '../file.js';
 
 import { CompasSettings } from '../compas/CompasSettings.js';
 import {
-  extractSclFromResponse, getWebsocketUri,
+  extractSclFromResponse,
+  getWebsocketUri,
   handleError,
   handleResponse,
-  parseXml
+  parseXml,
 } from './foundation.js';
-import { Websockets } from './Websockets.js';
+import { websockets } from './Websockets.js';
 
 export const SDS_NAMESPACE =
   'https://www.lfenergy.org/compas/SclDataService/v1';
@@ -35,22 +36,18 @@ export function CompasSclDataService() {
     return CompasSettings().compasSettings.sclDataServiceUrl;
   }
 
+  function useWebsocket(): boolean {
+    return CompasSettings().useWebsockets();
+  }
+
+  function listSclTypes(): Promise<Document> {
+    const sclUrl = getSclDataServiceUrl() + '/common/v1/type/list';
+    return fetch(sclUrl).catch(handleError).then(handleResponse).then(parseXml);
+  }
+
   return {
-    useWebsocket(): boolean {
-      return CompasSettings().useWebsockets();
-    },
-
-    listSclTypes(): Promise<Document> {
-      const sclUrl =
-        getSclDataServiceUrl() + '/common/v1/type/list';
-      return fetch(sclUrl)
-        .catch(handleError)
-        .then(handleResponse)
-        .then(parseXml);
-    },
-
-    listSclTypesAndOrder(): Promise<Element[]> {
-      return this.listSclTypes().then(xmlResponse => {
+    listOrderedSclTypes(): Promise<Element[]> {
+      return listSclTypes().then(xmlResponse => {
         return Array.from(xmlResponse.querySelectorAll('*|Type') ?? []).sort(
           (type1, type2) => {
             const description1 =
@@ -68,77 +65,43 @@ export function CompasSclDataService() {
     },
 
     listScls(type: string): Promise<Document> {
-      const sclUrl =
-        getSclDataServiceUrl() + '/scl/v1/' + type + '/list';
+      const sclUrl = getSclDataServiceUrl() + '/scl/v1/' + type + '/list';
       return fetch(sclUrl)
         .catch(handleError)
         .then(handleResponse)
         .then(parseXml);
     },
 
-    listVersions(type: string, id: string): Promise<Document> {
+    listSclVersions(type: string, id: string): Promise<Document> {
       const sclUrl =
-        getSclDataServiceUrl() +
-        '/scl/v1/' +
-        type +
-        '/' +
-        id +
-        '/versions';
+        getSclDataServiceUrl() + '/scl/v1/' + type + '/' + id + '/versions';
       return fetch(sclUrl)
         .catch(handleError)
         .then(handleResponse)
         .then(parseXml);
     },
 
-    getSclDocumentUsingRest(
+    getSclDocument(
+      element: Element,
       type: string,
       id: string
     ): Promise<Document> {
-      const sclUrl =
-        getSclDataServiceUrl() + '/scl/v1/' + type + '/' + id;
-      return fetch(sclUrl)
-        .catch(handleError)
-        .then(handleResponse)
-        .then(parseXml)
-        .then(extractSclFromResponse);
-    },
-
-    getSclDocumentUsingWebsockets(
-      element: Element,
-      type: string,
-      id: string,
-      callback: (scl: Document) => void,
-    ) {
-      const request =
-        `<?xml version="1.0" encoding="UTF-8"?>
+      if (useWebsocket()) {
+        const request = `<?xml version="1.0" encoding="UTF-8"?>
          <sds:GetWsRequest xmlns:sds="${SDS_NAMESPACE}">
            <sds:Id>${id}</sds:Id>
          </sds:GetWsRequest>`;
 
-      const sclUrl = getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/get';
-      Websockets(element, 'CompasSclDataService').execute(
-        getWebsocketUri(sclUrl),
-        request,
-        async (response: Document) => {
-          const scl = await extractSclFromResponse(response);
-          callback(scl);
-        }
-      );
-    },
+        const sclUrl = getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/get';
+        return websockets(
+          element,
+          'CompasSclDataService',
+          getWebsocketUri(sclUrl),
+          request
+        ).then(extractSclFromResponse);
+      }
 
-    getSclDocumentVersionUsingRest(
-      type: string,
-      id: string,
-      version: string
-    ): Promise<Document> {
-      const sclUrl =
-        getSclDataServiceUrl() +
-        '/scl/v1/' +
-        type +
-        '/' +
-        id +
-        '/' +
-        version;
+      const sclUrl = getSclDataServiceUrl() + '/scl/v1/' + type + '/' + id;
       return fetch(sclUrl)
         .catch(handleError)
         .then(handleResponse)
@@ -146,29 +109,36 @@ export function CompasSclDataService() {
         .then(extractSclFromResponse);
     },
 
-    getSclDocumentVersionUsingWebsockets(
+    getSclDocumentVersion(
       element: Element,
       type: string,
       id: string,
-      version: string,
-      callback: (scl: Document) => void,
-    ) {
-      const request =
-        `<?xml version="1.0" encoding="UTF-8"?>
+      version: string
+    ): Promise<Document> {
+      if (useWebsocket()) {
+        const request = `<?xml version="1.0" encoding="UTF-8"?>
          <sds:GetVersionWsRequest xmlns:sds="${SDS_NAMESPACE}">
            <sds:Id>${id}</sds:Id>
            <sds:Version>${version}</sds:Version>
          </sds:GetVersionWsRequest>`;
 
-      const sclUrl = getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/get-version';
-      Websockets(element, 'CompasSclDataService').execute(
-        getWebsocketUri(sclUrl),
-        request,
-        async (response: Document) => {
-          const scl = await extractSclFromResponse(response);
-          callback(scl);
-        }
-      );
+        const sclUrl =
+          getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/get-version';
+        return websockets(
+          element,
+          'CompasSclDataService',
+          getWebsocketUri(sclUrl),
+          request
+        ).then(extractSclFromResponse);
+      }
+
+      const sclUrl =
+        getSclDataServiceUrl() + '/scl/v1/' + type + '/' + id + '/' + version;
+      return fetch(sclUrl)
+        .catch(handleError)
+        .then(handleResponse)
+        .then(parseXml)
+        .then(extractSclFromResponse);
     },
 
     deleteSclDocumentVersion(
@@ -177,35 +147,51 @@ export function CompasSclDataService() {
       version: string
     ): Promise<string> {
       const sclUrl =
-        getSclDataServiceUrl() +
-        '/scl/v1/' +
-        type +
-        '/' +
-        id +
-        '/' +
-        version;
+        getSclDataServiceUrl() + '/scl/v1/' + type + '/' + id + '/' + version;
       return fetch(sclUrl, { method: 'DELETE' })
         .catch(handleError)
         .then(handleResponse);
     },
 
     deleteSclDocument(type: string, id: string): Promise<string> {
-      const sclUrl =
-        getSclDataServiceUrl() + '/scl/v1/' + type + '/' + id;
+      const sclUrl = getSclDataServiceUrl() + '/scl/v1/' + type + '/' + id;
       return fetch(sclUrl, { method: 'DELETE' })
         .catch(handleError)
         .then(handleResponse);
     },
 
-    addSclDocumentUsingRest(type: string, body: CreateRequestBody): Promise<Document> {
-      const request =
-        `<?xml version="1.0" encoding="UTF-8"?>
+    addSclDocument(
+      element: Element,
+      type: string,
+      body: CreateRequestBody
+    ): Promise<Document> {
+      if (useWebsocket()) {
+        const request = `<?xml version="1.0" encoding="UTF-8"?>
+         <sds:CreateWsRequest xmlns:sds="${SDS_NAMESPACE}">
+           <sds:Name>${body.sclName}</sds:Name>
+           <sds:Comment>${body.comment ?? ''}</sds:Comment>
+           <sds:SclData><![CDATA[${formatXml(
+             new XMLSerializer().serializeToString(body.doc.documentElement)
+           )}]]></sds:SclData>
+         </sds:CreateWsRequest>`;
+
+        const sclUrl =
+          getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/create';
+        return websockets(
+          element,
+          'CompasSclDataService',
+          getWebsocketUri(sclUrl),
+          request
+        ).then(extractSclFromResponse);
+      }
+
+      const request = `<?xml version="1.0" encoding="UTF-8"?>
          <sds:CreateRequest xmlns:sds="${SDS_NAMESPACE}">
             <sds:Name>${body.sclName}</sds:Name>
             <sds:Comment>${body.comment ?? ''}</sds:Comment>
             <sds:SclData><![CDATA[${formatXml(
-               new XMLSerializer().serializeToString(
-                 body.doc.documentElement))}]]></sds:SclData>
+              new XMLSerializer().serializeToString(body.doc.documentElement)
+            )}]]></sds:SclData>
          </sds:CreateRequest>`;
 
       const sclUrl = getSclDataServiceUrl() + '/scl/v1/' + type;
@@ -222,50 +208,43 @@ export function CompasSclDataService() {
         .then(extractSclFromResponse);
     },
 
-    addSclDocumentUsingWebsockets(
+    updateSclDocument(
       element: Element,
-      type: string,
-      body: CreateRequestBody,
-      callback: (scl: Document) => void,
-    ) {
-      const request =
-        `<?xml version="1.0" encoding="UTF-8"?>
-         <sds:CreateWsRequest xmlns:sds="${SDS_NAMESPACE}">
-           <sds:Name>${body.sclName}</sds:Name>
-           <sds:Comment>${body.comment ?? ''}</sds:Comment>
-           <sds:SclData><![CDATA[${formatXml(
-             new XMLSerializer().serializeToString(
-               body.doc.documentElement))}]]></sds:SclData>
-         </sds:CreateWsRequest>`;
-
-      const sclUrl = getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/create';
-      Websockets(element, 'CompasSclDataService').execute(
-        getWebsocketUri(sclUrl),
-        request,
-        async (response: Document) => {
-          const scl = await extractSclFromResponse(response);
-          callback(scl);
-        }
-      );
-    },
-
-    updateSclDocumentUsingRest(
       type: string,
       id: string,
       body: UpdateRequestBody
     ): Promise<Document> {
-      const request =
-        `<?xml version="1.0" encoding="UTF-8"?>
+      if (useWebsocket()) {
+        const request = `<?xml version="1.0" encoding="UTF-8"?>
+         <sds:UpdateWsRequest xmlns:sds="${SDS_NAMESPACE}">
+           <sds:Id>${id}</sds:Id>
+           <sds:ChangeSet>${body.changeSet}</sds:ChangeSet>
+           <sds:Comment>${body.comment ?? ''}</sds:Comment>
+           <sds:SclData><![CDATA[${formatXml(
+             new XMLSerializer().serializeToString(body.doc.documentElement)
+           )}]]></sds:SclData>
+         </sds:UpdateWsRequest>`;
+
+        const sclUrl =
+          getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/update';
+        return websockets(
+          element,
+          'CompasSclDataService',
+          getWebsocketUri(sclUrl),
+          request
+        ).then(extractSclFromResponse);
+      }
+
+      const request = `<?xml version="1.0" encoding="UTF-8"?>
          <sds:UpdateRequest xmlns:sds="${SDS_NAMESPACE}">
            <sds:ChangeSet>${body.changeSet}</sds:ChangeSet>
            <sds:Comment>${body.comment ?? ''}</sds:Comment>
            <sds:SclData><![CDATA[${formatXml(
-             new XMLSerializer().serializeToString(
-               body.doc.documentElement))}]]></sds:SclData>
+             new XMLSerializer().serializeToString(body.doc.documentElement)
+           )}]]></sds:SclData>
          </sds:UpdateRequest>`;
 
-      const sclUrl =
-        getSclDataServiceUrl() + '/scl/v1/' + type + '/' + id;
+      const sclUrl = getSclDataServiceUrl() + '/scl/v1/' + type + '/' + id;
       return fetch(sclUrl, {
         method: 'PUT',
         headers: {
@@ -277,35 +256,6 @@ export function CompasSclDataService() {
         .then(handleResponse)
         .then(parseXml)
         .then(extractSclFromResponse);
-    },
-
-    updateSclDocumentUsingWebsockets(
-      element: Element,
-      type: string,
-      id: string,
-      body: UpdateRequestBody,
-      callback: (scl: Document) => void,
-    ) {
-      const request =
-        `<?xml version="1.0" encoding="UTF-8"?>
-         <sds:UpdateWsRequest xmlns:sds="${SDS_NAMESPACE}">
-           <sds:Id>${id}</sds:Id>
-           <sds:ChangeSet>${body.changeSet}</sds:ChangeSet>
-           <sds:Comment>${body.comment ?? ''}</sds:Comment>
-           <sds:SclData><![CDATA[${formatXml(
-          new XMLSerializer().serializeToString(
-            body.doc.documentElement))}]]></sds:SclData>
-         </sds:UpdateWsRequest>`
-
-      const sclUrl = getSclDataServiceUrl() + '/scl-ws/v1/' + type + '/update';
-      Websockets(element, 'CompasSclDataService').execute(
-        getWebsocketUri(sclUrl),
-        request,
-        async (response: Document) => {
-          const scl = await extractSclFromResponse(response);
-          callback(scl);
-        }
-      );
     },
   };
 }

--- a/src/compas-services/CompasValidatorService.ts
+++ b/src/compas-services/CompasValidatorService.ts
@@ -1,5 +1,5 @@
 import { CompasSettings } from '../compas/CompasSettings.js';
-import { websockets } from './Websockets.js';
+import { websocket } from './Websocket.js';
 import {
   getWebsocketUri,
   handleError,
@@ -35,7 +35,7 @@ export function CompasSclValidatorService() {
       doc: Document
     ): Promise<Document> {
       if (useWebsocket()) {
-        return websockets(
+        return websocket(
           element,
           'CompasValidatorService',
           getWebsocketUri(getSclValidatorServiceUrl()) +

--- a/src/compas-services/Websocket.ts
+++ b/src/compas-services/Websocket.ts
@@ -1,7 +1,6 @@
 import { newPendingStateEvent } from '../foundation.js';
 import {
   APPLICATION_ERROR,
-  createLogEvent,
   extractErrorMessage,
   parseXml,
   SERVER_ERROR,
@@ -44,7 +43,7 @@ export function websocket(
           websocket?.close();
         })
         .catch(reason => {
-          createLogEvent(element, reason);
+          reject(reason);
           websocket?.close();
         });
     };
@@ -52,7 +51,7 @@ export function websocket(
     websocket.onerror = () => {
       reject({
         type: SERVER_ERROR,
-        mesage: `Websocket Error in service "${serviceName}"`,
+        message: `Websocket Error in service "${serviceName}"`,
       });
       websocket?.close();
     };

--- a/src/compas-services/Websocket.ts
+++ b/src/compas-services/Websocket.ts
@@ -7,7 +7,7 @@ import {
   SERVER_ERROR,
 } from './foundation.js';
 
-export function websockets(
+export function websocket(
   element: Element,
   serviceName: string,
   url: string,

--- a/src/compas-services/Websockets.ts
+++ b/src/compas-services/Websockets.ts
@@ -1,7 +1,18 @@
 import { newPendingStateEvent } from '../foundation.js';
-import { APPLICATION_ERROR, createLogEvent, extractErrorMessage, parseXml } from './foundation.js';
+import {
+  APPLICATION_ERROR,
+  createLogEvent,
+  extractErrorMessage,
+  parseXml,
+  SERVER_ERROR,
+} from './foundation.js';
 
-export function Websockets(element: Element, serviceName: string) {
+export function websockets(
+  element: Element,
+  serviceName: string,
+  url: string,
+  request: string
+): Promise<Document> {
   let websocket: WebSocket | undefined;
 
   function sleep(sleepTime: number): Promise<unknown> {
@@ -14,52 +25,41 @@ export function Websockets(element: Element, serviceName: string) {
     }
   }
 
-  return {
-    execute(
-      url: string,
-      request: string,
-      onMessageCallback: (doc: Document) => void,
-      onCloseCallback?: () => void
-    ) {
-      websocket = new WebSocket(url);
+  return new Promise<Document>((resolve, reject) => {
+    websocket = new WebSocket(url);
 
-      websocket.onopen = () => {
-        websocket?.send(request);
-      };
+    websocket.onopen = () => {
+      websocket?.send(request);
+    };
 
-      websocket.onmessage = evt => {
-        parseXml(evt.data)
-          .then(doc => {
-            if (doc.documentElement.localName === 'ErrorResponse') {
-              const message = extractErrorMessage(doc);
-              createLogEvent(element, {type: APPLICATION_ERROR, message});
-            } else {
-              onMessageCallback(doc);
-            }
-            websocket?.close();
-          })
-          .catch(reason => {
-            createLogEvent(element, reason);
-            websocket?.close();
-          });
-      };
-
-      websocket.onerror = () => {
-        createLogEvent(element, {
-          message: `Websocket Error in service "${serviceName}"`,
-          type: 'Error',
+    websocket.onmessage = evt => {
+      parseXml(evt.data)
+        .then(doc => {
+          if (doc.documentElement.localName === 'ErrorResponse') {
+            const message = extractErrorMessage(doc);
+            reject({ type: APPLICATION_ERROR, message });
+          } else {
+            resolve(doc);
+          }
+          websocket?.close();
+        })
+        .catch(reason => {
+          createLogEvent(element, reason);
+          websocket?.close();
         });
-        websocket?.close();
-      };
+    };
 
-      websocket.onclose = () => {
-        websocket = undefined;
-        if (onCloseCallback) {
-          onCloseCallback();
-        }
-      };
+    websocket.onerror = () => {
+      reject({
+        type: SERVER_ERROR,
+        mesage: `Websocket Error in service "${serviceName}"`,
+      });
+      websocket?.close();
+    };
+    websocket.onclose = () => {
+      websocket = undefined;
+    };
 
-      element.dispatchEvent(newPendingStateEvent(waitUntilExecuted()));
-    },
-  };
+    element.dispatchEvent(newPendingStateEvent(waitUntilExecuted()));
+  });
 }

--- a/src/compas/CompasExistsIn.ts
+++ b/src/compas/CompasExistsIn.ts
@@ -36,7 +36,7 @@ export function CompasExistsIn<TBase extends LitElementConstructor>(
     callService(docType: string, docId: string): Promise<Document> {
       // Use the versions call to check if any exist, because then the document also exists
       // And it saves bandwidth not to retrieve the whole document.
-      return CompasSclDataService().listVersions(docType, docId);
+      return CompasSclDataService().listSclVersions(docType, docId);
     }
 
     checkExistInCompas(): void {

--- a/src/compas/CompasOpen.ts
+++ b/src/compas/CompasOpen.ts
@@ -56,19 +56,9 @@ export default class CompasOpenElement extends LitElement {
   private sclFileUI!: HTMLInputElement;
 
   private async getSclDocument(docId?: string): Promise<void> {
-    const service = CompasSclDataService();
-    const doc = service.useWebsocket()
-      ? await new Promise((resolve) => {
-          service.getSclDocumentUsingWebsockets(
-            this,
-            this.selectedType ?? '',
-            docId ?? '',
-            (doc) => resolve(doc)
-          )
-        })
-      : await service
-        .getSclDocumentUsingRest(this.selectedType ?? '', docId ?? '')
-        .catch(reason => createLogEvent(this, reason));
+    const doc = await CompasSclDataService()
+      .getSclDocument(this, this.selectedType ?? '', docId ?? '')
+      .catch(reason => createLogEvent(this, reason));
 
     if (doc instanceof Document) {
       const docName = buildDocName(doc.documentElement);

--- a/src/compas/CompasSclTypeList.ts
+++ b/src/compas/CompasSclTypeList.ts
@@ -1,19 +1,26 @@
-import {customElement, html, LitElement, property, TemplateResult} from "lit-element";
-import {translate} from "lit-translate";
+import {
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult,
+} from 'lit-element';
+import { translate } from 'lit-translate';
 
 import '@material/mwc-list';
 import '@material/mwc-list/mwc-list-item';
 
-import {CompasSclDataService, SDS_NAMESPACE} from "../compas-services/CompasSclDataService.js";
+import {
+  CompasSclDataService,
+  SDS_NAMESPACE,
+} from '../compas-services/CompasSclDataService.js';
 
 /* Event that will be used when a SCL Type is selected from a list of types. */
 export interface TypeSelectedDetail {
   type: string;
 }
 export type TypeSelectedEvent = CustomEvent<TypeSelectedDetail>;
-export function newTypeSelectedEvent(
-  type: string
-): TypeSelectedEvent {
+export function newTypeSelectedEvent(type: string): TypeSelectedEvent {
   return new CustomEvent<TypeSelectedDetail>('typeSelected', {
     bubbles: true,
     composed: true,
@@ -31,34 +38,37 @@ export class CompasSclTypeList extends LitElement {
   }
 
   fetchData(): void {
-    CompasSclDataService().listSclTypesAndOrder()
-      .then(types => this.sclTypes = types);
+    CompasSclDataService()
+      .listOrderedSclTypes()
+      .then(types => (this.sclTypes = types));
   }
 
   render(): TemplateResult {
-      if (!this.sclTypes) {
-        return html `
-          <compas-loading></compas-loading>
-        `
-      }
+    if (!this.sclTypes) {
+      return html` <compas-loading></compas-loading> `;
+    }
 
-      if (this.sclTypes.length <= 0) {
-        return html `
-          <mwc-list>
-            <mwc-list-item><i>${translate("compas.noSclTypes")}</i></mwc-list-item>
-         </mwc-list>`
-      }
+    if (this.sclTypes.length <= 0) {
+      return html` <mwc-list>
+        <mwc-list-item><i>${translate('compas.noSclTypes')}</i></mwc-list-item>
+      </mwc-list>`;
+    }
 
-      return html`
-        <mwc-list>
-          ${this.sclTypes.map( type => {
-              const code = type.getElementsByTagNameNS(SDS_NAMESPACE, "Code").item(0)!.textContent ?? '';
-              const description = type.getElementsByTagNameNS(SDS_NAMESPACE, "Description").item(0)!.textContent ?? '';
-              return html`<mwc-list-item tabindex="0"
-                                         @click=${() => this.dispatchEvent(newTypeSelectedEvent(code))}>
-                            <span>${description} (${code})</span>
-                          </mwc-list-item>`;
-            })}
-        </mwc-list>`
-     }
+    return html` <mwc-list>
+      ${this.sclTypes.map(type => {
+        const code =
+          type.getElementsByTagNameNS(SDS_NAMESPACE, 'Code').item(0)!
+            .textContent ?? '';
+        const description =
+          type.getElementsByTagNameNS(SDS_NAMESPACE, 'Description').item(0)!
+            .textContent ?? '';
+        return html`<mwc-list-item
+          tabindex="0"
+          @click=${() => this.dispatchEvent(newTypeSelectedEvent(code))}
+        >
+          <span>${description} (${code})</span>
+        </mwc-list-item>`;
+      })}
+    </mwc-list>`;
+  }
 }

--- a/src/compas/CompasSclTypeSelect.ts
+++ b/src/compas/CompasSclTypeSelect.ts
@@ -33,7 +33,7 @@ export class CompasSclTypeSelect extends LitElement {
 
   fetchData(): void {
     CompasSclDataService()
-      .listSclTypesAndOrder()
+      .listOrderedSclTypes()
       .then(types => (this.sclTypes = types));
   }
 

--- a/src/compas/CompasUploadVersion.ts
+++ b/src/compas/CompasUploadVersion.ts
@@ -85,29 +85,16 @@ export class CompasUploadVersionElement extends CompasExistsIn(LitElement) {
     const text = await file.text();
     const doc = new DOMParser().parseFromString(text, 'application/xml');
 
-    const service = CompasSclDataService();
-    if (service.useWebsocket()) {
-      service.updateSclDocumentUsingWebsockets(
-        this,
-        docType,
-        this.docId!,
-        { changeSet: changeSet!, comment: comment, doc: doc },
-        (sclDocument: Document) => {
-          this.processAddDocument(sclDocument);
-        }
-      )
-    } else {
-      await service
-        .updateSclDocumentUsingRest(docType, this.docId!, {
-          changeSet: changeSet!,
-          comment: comment,
-          doc: doc,
-        })
-        .then(sclDocument => {
-          this.processAddDocument(sclDocument);
-        })
-        .catch(reason => createLogEvent(this, reason));
-    }
+    await CompasSclDataService()
+      .updateSclDocument(this, docType, this.docId!, {
+        changeSet: changeSet!,
+        comment: comment,
+        doc: doc,
+      })
+      .then(sclDocument => {
+        this.processAddDocument(sclDocument);
+      })
+      .catch(reason => createLogEvent(this, reason));
   }
 
   render(): TemplateResult {


### PR DESCRIPTION
@juancho0202 as already told a nicer version for using websocket.

The websocket function now returns a Promise<Document> like most rest calls are also doing after some response handling.
If something goes wrong a reject is done with the reason body as used in other places with rest calls.
This way the handling if websocket or rest should be used could be hidden in the service layer. 
Calling code doesn't know anymore.

Remark: I created a local container image and used the Docker Compose file and robot test script to validate the change.
