### PR TITLE
fix: making importIEDS dialog's id unique

### DIFF
--- a/src/menu/CompasImportIEDs.ts
+++ b/src/menu/CompasImportIEDs.ts
@@ -11,12 +11,12 @@ export default class CompasImportIEDSMenuPlugin extends ImportingIedPlugin {
   doc!: XMLDocument;
   parent!: HTMLElement;
 
-  @query('mwc-dialog#compas-open-dlg')
+  @query('mwc-dialog#compas-import-ieds-dlg')
   compasOpen!: Dialog;
 
   renderInput(): TemplateResult {
     return html`<mwc-dialog
-      id="compas-open-dlg"
+      id="compas-import-ieds-dlg"
       heading="${translate('compas.open.title')}"
     >
       <compas-open


### PR DESCRIPTION
Fix for error found in compas-deployment:

`Error: locator.click: Error: strict mode violation: "mwc-dialog#compas-open-dlg > compas-open mwc-button[label="Open file..."] button" resolved to 2 elements:
    1) <button id="button" class="mdc-button  " aria-label="Ope…>…</button> aka playwright.$("oscd-plugin8377febe1fad1914 [aria-label="Open file\.\.\."]")
    2) <button id="button" class="mdc-button  " aria-label="Ope…>…</button> aka playwright.$("oscd-pluginb15ea127292dd242 [aria-label="Open file\.\.\."]")
`