### PR TITLE
fix: Exclude nsdoc readme from service worker

### DIFF
--- a/packages/compas-open-scd/workbox-config.cjs
+++ b/packages/compas-open-scd/workbox-config.cjs
@@ -7,6 +7,9 @@ module.exports = {
     'src/**/*.{md,js,png,xml,pdf,css,html,info,json,ico,svg,wasm}',
     '*.{md,json,ico,xml}',
   ],
+  globIgnores: [
+    'public/nsdoc/README.md'
+  ],
   swDest: 'build/sw.js',
   runtimeCaching: [
     {


### PR DESCRIPTION
The readme is for dev purposes only and is not used in the deployed version