### PR TITLE
fix: add version to cacheId + add package.json to SW caching

### DIFF
--- a/packages/compas-open-scd/workbox-config.cjs
+++ b/packages/compas-open-scd/workbox-config.cjs
@@ -17,7 +17,7 @@ module.exports = {
   runtimeCaching: [
     {
       urlPattern: /package\.json\.proxy\.js$/,
-      handler: 'NetworkOnly',
+      handler: 'NetworkFirst',
     },
     {
       urlPattern: /\/(_snowpack|public|src)\/.*/,

--- a/packages/compas-open-scd/workbox-config.cjs
+++ b/packages/compas-open-scd/workbox-config.cjs
@@ -7,6 +7,8 @@ module.exports = {
     '_snowpack/**/*.{md,js,png,xml,pdf,css,html,info,json,ico,svg,wasm}',
     'public/**/*.{md,js,png,xml,pdf,css,html,info,json,ico,svg,wasm}',
     'src/**/*.{md,js,png,xml,pdf,css,html,info,json,ico,svg,wasm}',
+    'plugins/**/*.{md,js,png,xml,pdf,css,html,info,json,ico,svg,wasm}',
+    'external-plugins/**/*.{md,js,png,xml,pdf,css,html,info,json,ico,svg,wasm}',
     '*.{md,json,ico,xml}',
     'package.json.proxy.js',
   ],

--- a/packages/compas-open-scd/workbox-config.cjs
+++ b/packages/compas-open-scd/workbox-config.cjs
@@ -1,17 +1,24 @@
+const packageJson = require('./package.json');
+
 module.exports = {
-  cacheId: 'compas',
+  cacheId: `compas-${packageJson.version}`,
   globDirectory: 'build/',
   globPatterns: [
     '_snowpack/**/*.{md,js,png,xml,pdf,css,html,info,json,ico,svg,wasm}',
     'public/**/*.{md,js,png,xml,pdf,css,html,info,json,ico,svg,wasm}',
     'src/**/*.{md,js,png,xml,pdf,css,html,info,json,ico,svg,wasm}',
     '*.{md,json,ico,xml}',
+    'package.json.proxy.js',
   ],
   globIgnores: [
     'public/nsdoc/README.md'
   ],
   swDest: 'build/sw.js',
   runtimeCaching: [
+    {
+      urlPattern: /package\.json\.proxy\.js$/,
+      handler: 'NetworkOnly',
+    },
     {
       urlPattern: /\/(_snowpack|public|src)\/.*/,
       handler: 'NetworkFirst',
@@ -20,10 +27,11 @@ module.exports = {
         fetchOptions: {
           credentials: 'include',
         },
-      }
+      },
     },
   ],
   skipWaiting: true,
+  clientsClaim: true,
   inlineWorkboxRuntime: true,
   cleanupOutdatedCaches: true,
 };


### PR DESCRIPTION
* The `cacheId` is now dynamically set to include the package version, in order to create a unique cache for each release.
* Added a new caching rule for `package.json.proxy.js`. This ensures the app always fetches the latest version, so it can clear plugins from localStorage if the version changes.
* `clientsClaim` was added to ensure the new service worker takes control of all pages as soon as it's activated.
