### PR TITLE
fix: 377 add wizard plugin for substation designer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,7 @@
 	path = packages/external-plugins/scl-bay-template
 	url = https://github.com/com-pas/scl-bay-template
 	branch = deploy
+[submodule "packages/external-plugins/scl-wizarding"]
+	path = packages/external-plugins/scl-wizarding
+	url = https://github.com/openenergytools/scl-wizarding
+	branch = deploy

--- a/packages/compas-open-scd/package.json
+++ b/packages/compas-open-scd/package.json
@@ -70,7 +70,7 @@
     "release:major": "standard-version --release-as major",
     "build:test": "npm run test && npm run build && cp .nojekyll build/",
     "build": "npm run doc && npm run build:only && cp .nojekyll build/",
-    "build:only": "snowpack build && workbox generateSW workbox-config.cjs",
+    "build:only": "npx rimraf node_modules/.cache/snowpack/build/lit@2.8.0 && snowpack build && workbox generateSW workbox-config.cjs",
     "__comment:start": "snowpack dev fails if the lit package is cached. I don't know why, but we have to delete it before starting",
     "start": "npx rimraf node_modules/.cache/snowpack/build/lit@2.8.0 && snowpack dev"
   },

--- a/packages/compas-open-scd/public/js/plugins.js
+++ b/packages/compas-open-scd/public/js/plugins.js
@@ -340,6 +340,15 @@ export const officialPlugins = [
     position: 'middle',
   },
   {
+    name: 'Wizarding',
+    src: '/external-plugins/scl-wizarding/scl-wizarding.js',
+    icon: 'edit',
+    activeByDefault: true,
+    kind: 'menu',
+    requireDoc: true,
+    position: 'middle',
+  },
+  {
     name: 'Show SCL History',
     src: '/plugins/src/menu/SclHistory.js',
     icon: 'history_toggle_off',

--- a/packages/compas-open-scd/src/menu/CompasOpen.ts
+++ b/packages/compas-open-scd/src/menu/CompasOpen.ts
@@ -28,9 +28,6 @@ export default class CompasOpenMenuPlugin extends LitElement {
     this.compasOpenElement.selectedType = undefined;
     await this.compasOpenElement.requestUpdate();
 
-    // TODO: Fix for dialog, the menu has to be open to see the dialog
-    this.dispatchEvent(compasOpenMenuEvent());
-
     this.dialog.show();
   }
 

--- a/packages/compas-open-scd/src/plugin-tag.ts
+++ b/packages/compas-open-scd/src/plugin-tag.ts
@@ -1,0 +1,18 @@
+export function pluginTag(uri: string): string {
+    let h1 = 0xdeadbeef,
+    h2 = 0x41c6ce57;
+    for (let i = 0, ch; i < uri.length; i++) {
+    ch = uri.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+    h1 =
+    Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+    Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 =
+    Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+    Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    return 'oscd-plugin' +
+        ((h2 >>> 0).toString(16).padStart(8, '0') +
+        (h1 >>> 0).toString(16).padStart(8, '0'))
+}

--- a/packages/openscd/src/open-scd.ts
+++ b/packages/openscd/src/open-scd.ts
@@ -493,6 +493,7 @@ declare global {
 export interface MenuItem {
   icon: string;
   name: string;
+  src?: string;
   hint?: string;
   actionItem?: boolean;
   action?: (event: CustomEvent<ActionDetail>) => void;


### PR DESCRIPTION
closes #377 

Extract menu item content from menu drawer, this also fixes the compas open bug, where we needed to open the menu to launch the open dialog