### PR TITLE
chore: update Communication Explorer plugin to version 0.0.32

### DIFF
--- a/packages/compas-open-scd/public/js/plugins.js
+++ b/packages/compas-open-scd/public/js/plugins.js
@@ -97,7 +97,7 @@ export const officialPlugins = [
   },
   {
     name: 'Communication Explorer',
-    src: '/external-plugins/oscd-plugins/communication-explorer/0.0.31/index.js',
+    src: '/external-plugins/oscd-plugins/communication-explorer/0.0.32/index.js',
     icon: 'lan',
     activeByDefault: true,
     kind: 'editor',

--- a/packages/compas-open-scd/snowpack.config.mjs
+++ b/packages/compas-open-scd/snowpack.config.mjs
@@ -30,6 +30,7 @@ export default ({
     "**/.github/**",
     "**/.idea/**",
     "**/web-test-runner.config.mjs",
+    "**/oscd-plugins/auto-doc/**/*",
   ],
   workspaceRoot: "../../",
   mount: {


### PR DESCRIPTION
closes #402 