### PR TITLE
fix: Use port 8080 for nginx

### DIFF
--- a/packages/compas-open-scd/Dockerfile
+++ b/packages/compas-open-scd/Dockerfile
@@ -1,5 +1,9 @@
 FROM public.ecr.aws/nginx/nginx:1.29.1
+
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY build/. /usr/share/nginx/html
+
+EXPOSE 8080
 
 VOLUME /etc/nginx/
 VOLUME /usr/share/nginx/html/public/cim

--- a/packages/compas-open-scd/nginx.conf
+++ b/packages/compas-open-scd/nginx.conf
@@ -1,0 +1,21 @@
+events {
+  worker_connections  1024;
+}
+
+http {
+  server {
+    listen       8080;
+    listen  [::]:8080;
+    server_name  localhost;
+
+    location / {
+      root   /usr/share/nginx/html;
+      index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+      root   /usr/share/nginx/html;
+    }
+  }
+}


### PR DESCRIPTION
The default nginx port is 80 in aws/nginx, but it was 8080 in the previously used bitnami/nginx docker image, so we have to explicitly set the port to 8080