### PR TITLE
feat(communication): add unique ip in subnetwork check

### DIFF
--- a/packages/plugins/src/wizards/connectedap.ts
+++ b/packages/plugins/src/wizards/connectedap.ts
@@ -333,7 +333,7 @@ function getIpsInSubnetwork(element: Element): string[] {
   const subnetwork = element.closest('SubNetwork');
   if (!subnetwork) return [];
 
-  return Array.from(subnetwork.querySelectorAll('ConnectedAP > Address > P[type="IP"]'))
+  return Array.from(subnetwork.querySelectorAll(':scope > ConnectedAP > Address > P[type="IP"]'))
     .map(p => p.textContent?.trim() ?? '')
     .filter(ip => ip !== '');
 }
@@ -343,7 +343,7 @@ export function createPTextField(
   pType: string
 ): TemplateResult {
     const currentValue =
-      element.querySelector(`:scope > Address > P[type="${pType}"]`)?.innerHTML ??
+      element.querySelector(`:scope > Address > P[type="${pType}"]`)?.textContent?.trim() ??
       null;
 
     let reservedIPs: string[] = [];

--- a/packages/plugins/src/wizards/connectedap.ts
+++ b/packages/plugins/src/wizards/connectedap.ts
@@ -329,18 +329,36 @@ export function createTypeRestrictionCheckbox(
   </mwc-formfield>`;
 }
 
+function getIpsInSubnetwork(element: Element): string[] {
+  const subnetwork = element.closest('SubNetwork');
+  if (!subnetwork) return [];
+
+  return Array.from(subnetwork.querySelectorAll('ConnectedAP > Address > P[type="IP"]'))
+    .map(p => p.textContent?.trim() ?? '')
+    .filter(ip => ip !== '');
+}
+
 export function createPTextField(
   element: Element,
   pType: string
 ): TemplateResult {
+    const currentValue =
+      element.querySelector(`:scope > Address > P[type="${pType}"]`)?.innerHTML ??
+      null;
+
+    let reservedIPs: string[] = [];
+    if (pType === 'IP') {
+      reservedIPs = getIpsInSubnetwork(element).filter(ip => ip !== currentValue);
+    }
+
   return oscdHtml`<wizard-textfield
     required
     label="${pType}"
     pattern="${ifDefined(typePattern[pType])}"
     ?nullable=${typeNullable[pType]}
-    .maybeValue=${element.querySelector(`:scope > Address > P[type="${pType}"]`)
-      ?.innerHTML ?? null}
+    .maybeValue=${currentValue}
     maxLength="${ifDefined(typeMaxLength[pType])}"
+    .reservedValues=${reservedIPs}
   ></wizard-textfield>`;
 }
 

--- a/packages/plugins/src/wizards/connectedap.ts
+++ b/packages/plugins/src/wizards/connectedap.ts
@@ -330,7 +330,7 @@ export function createTypeRestrictionCheckbox(
 }
 
 function getIpsInSubnetwork(element: Element): string[] {
-  const subnetwork = element.closest('SubNetwork');
+  const subnetwork = element.parentElement; // SubNetwork is the parent of ConnectedAP
   if (!subnetwork) return [];
 
   return Array.from(subnetwork.querySelectorAll(':scope > ConnectedAP > Address > P[type="IP"]'))


### PR DESCRIPTION
# Communication Plugin Unique IP

The input is checked against existing IPs within the selected subnetwork, and a message is shown below the field if the IP is already assigned and unavailable.

<img width="495" height="313" alt="image" src="https://github.com/user-attachments/assets/46d37e81-3d61-4b42-94a0-ba50e29325e8" />

<img width="459" height="570" alt="image" src="https://github.com/user-attachments/assets/f76a7eb7-7497-44d7-b2fb-0fbfc770652e" />
