### PR TITLE
Fix #157 - CoMPAS - Adding a custom plugin with an existing name and kind creates duplicate entries

### DIFF
--- a/src/open-scd.ts
+++ b/src/open-scd.ts
@@ -188,7 +188,6 @@ export class OpenSCD extends LitElement {
    * @deprecated Use `handleConfigurationPluginEvent` instead
    */
   public handleAddExternalPlugin(e: AddExternalPluginEvent) {
-    this.addExternalPlugin(e.detail.plugin);
     const { name, kind } = e.detail.plugin;
 
     const event = newConfigurePluginEvent(name, kind, e.detail.plugin);
@@ -453,16 +452,6 @@ export class OpenSCD extends LitElement {
     const mergedPlugins = [...mergedBuiltInPlugins, ...userInstalledPlugins];
 
     this.updateStoredPlugins(mergedPlugins);
-  }
-
-  private async addExternalPlugin(
-    plugin: Omit<Plugin, 'content'>
-  ): Promise<void> {
-    if (this.storedPlugins.some(p => p.src === plugin.src)) return;
-
-    const newPlugins: Omit<Plugin, 'content'>[] = this.storedPlugins;
-    newPlugins.push(plugin);
-    this.storePlugins(newPlugins);
   }
 
   protected getBuiltInPlugins(): CorePlugin[] {


### PR DESCRIPTION
See https://github.com/com-pas/open-scd/issues/157